### PR TITLE
Fix class name typo

### DIFF
--- a/test/dog_test.rb
+++ b/test/dog_test.rb
@@ -2,7 +2,7 @@ require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/dog'
 
-class dogTest < Minitest::Test
+class DogTest < Minitest::Test
 
   def test_it_has_attributes
     dog = Dog.new("Comet", "German Shepherd")


### PR DESCRIPTION
This will cause test errors for students, Dog needs to be capitalized. @s-espinosa @BrianZanti 